### PR TITLE
Fix/seperation of control corrections

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -9,11 +9,9 @@ Traces to: UC-1, UC-5 | Domain class: User
 """
 
 import enum
-import uuid
 
 from fastapi_users_db_sqlmodel import SQLModelBaseUserDB
 from pydantic import field_validator
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import Field
 
 
@@ -58,27 +56,3 @@ class User(SQLModelBaseUserDB, table=True):
             allowed = ", ".join(r.value for r in UserRole)
             raise ValueError(f"Invalid role '{v}'. Must be one of: {allowed}")
 
-    @classmethod
-    async def admin_update(
-        cls,
-        user_id: uuid.UUID,
-        session: AsyncSession,
-        role: UserRole | None = None,
-        is_active: bool | None = None,
-    ) -> "User | None":
-        """
-        Updates a user's role or active status.
-        """
-        user = await session.get(cls, user_id)
-        if not user:
-            return None
-
-        if role is not None:
-            user.role = role
-        if is_active is not None:
-            user.is_active = is_active
-
-        session.add(user)
-        await session.commit()
-        await session.refresh(user)
-        return user

--- a/backend/app/routes/bookings.py
+++ b/backend/app/routes/bookings.py
@@ -16,21 +16,18 @@ from pydantic import BaseModel, ConfigDict
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.database import get_session
-from app.models import Booking, BookingStatus, NotificationType, RecurrenceFrequency, User
+from app.models import Booking, BookingStatus, RecurrenceFrequency, User
 from app.services.auth import current_active_user, require_admin
 from app.services.booking_service import (
     BookingConflictError,
     BookingNotFoundError,
     BookingServiceError,
     BookingStateError,
-    approve_booking,
-    cancel_booking,
-    deny_booking,
     get_all_bookings,
     get_user_bookings,
+    process_booking_action,
     submit_booking,
 )
-from app.services.notification_service import send_notification
 
 router = APIRouter(prefix="/api/bookings", tags=["bookings"])
 
@@ -134,29 +131,10 @@ async def update_booking(
     session: AsyncSession = Depends(get_session),
 ):
     del admin_user
-    action_to_service = {
-        "approve": approve_booking,
-        "deny": deny_booking,
-        "cancel": cancel_booking,
-    }
-    action_to_notification = {
-        "approve": NotificationType.APPROVED,
-        "deny": NotificationType.DENIED,
-        "cancel": NotificationType.CANCELLED,
-    }
-
     try:
         booking = await session.run_sync(
-            lambda sync_session: action_to_service[booking_update.action](
-                booking_id, sync_session
-            )
-        )
-        await session.run_sync(
-            lambda sync_session: send_notification(
-                booking.userID,
-                booking.id,
-                action_to_notification[booking_update.action],
-                sync_session,
+            lambda sync_session: process_booking_action(
+                booking_id, booking_update.action, sync_session
             )
         )
     except Exception as exc:

--- a/backend/app/routes/notifications.py
+++ b/backend/app/routes/notifications.py
@@ -15,10 +15,11 @@ from pydantic import BaseModel, ConfigDict
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.database import get_session
-from app.models import Notification, User
+from app.models import User
 from app.services.auth import current_active_user
 from app.services.notification_service import (
     NotificationNotFoundError,
+    get_notification_for_user,
     get_notifications,
     get_unread_count,
     mark_read,
@@ -31,7 +32,6 @@ class NotificationRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-    userID: UUID
     bookingID: int
     message: str
     type: str
@@ -42,17 +42,6 @@ class NotificationRead(BaseModel):
 class UnreadCountRead(BaseModel):
     count: int
 
-
-async def _get_owned_notification_or_404(
-    notification_id: int, user_id: UUID, session: AsyncSession
-) -> Notification:
-    notification = await session.get(Notification, notification_id)
-    if notification is None or notification.userID != user_id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Notification {notification_id} was not found.",
-        )
-    return notification
 
 
 @router.get("", response_model=list[NotificationRead])
@@ -78,9 +67,12 @@ async def read_notification(
     user: User = Depends(current_active_user),
     session: AsyncSession = Depends(get_session),
 ):
-    await _get_owned_notification_or_404(notification_id, user.id, session)
-
     try:
+        await session.run_sync(
+            lambda sync_session: get_notification_for_user(
+                notification_id, user.id, sync_session
+            )
+        )
         return await session.run_sync(
             lambda sync_session: mark_read(notification_id, sync_session)
         )

--- a/backend/app/routes/rooms.py
+++ b/backend/app/routes/rooms.py
@@ -14,7 +14,7 @@ Traces to: UC-2
 from datetime import date
 from typing import List
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.database import get_session
@@ -22,6 +22,7 @@ from app.models.user import User
 from app.schemas.room import RoomBasicRead, RoomRead
 from app.services.auth import current_active_user
 from app.services.room_service import (
+    RoomNotFoundError,
     get_available_dates,
     get_room,
     get_rooms_with_availability,
@@ -77,4 +78,9 @@ async def retrieve_room(
     Raises a 404 HTTP error if no room with the given ``id`` exists.
     Requires a valid authenticated user — unauthenticated requests receive 401.
     """
-    return await get_room(id, session)
+    try:
+        return await get_room(id, session)
+    except RoomNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -18,6 +18,7 @@ from .booking_service import (
     get_all_bookings,
     get_pending_bookings,
     get_user_bookings,
+    process_booking_action,
     submit_booking,
 )
 from .notification_service import (
@@ -47,6 +48,7 @@ __all__ = [
     "get_user_bookings",
     "get_all_bookings",
     "get_pending_bookings",
+    "process_booking_action",
     "NotificationServiceError",
     "NotificationNotFoundError",
     "RoomServiceError",

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -23,10 +23,16 @@ from .booking_service import (
 from .notification_service import (
     NotificationNotFoundError,
     NotificationServiceError,
+    get_notification_for_user,
     get_notifications,
     get_unread_count,
     mark_read,
     send_notification,
+)
+
+from .room_service import (
+    RoomNotFoundError,
+    RoomServiceError,
 )
 
 __all__ = [
@@ -43,8 +49,11 @@ __all__ = [
     "get_pending_bookings",
     "NotificationServiceError",
     "NotificationNotFoundError",
+    "RoomServiceError",
+    "RoomNotFoundError",
     "send_notification",
     "get_notifications",
+    "get_notification_for_user",
     "mark_read",
     "get_unread_count",
 ]

--- a/backend/app/services/booking_service.py
+++ b/backend/app/services/booking_service.py
@@ -14,11 +14,13 @@ from sqlmodel import Session, select
 from app.models import (
     Booking,
     BookingStatus,
+    NotificationType,
     RecurrenceFrequency,
     TimeSlot,
     TimeslotStatus,
     User,
 )
+from app.services.notification_service import send_notification
 
 
 class BookingServiceError(ValueError):
@@ -255,3 +257,17 @@ def get_all_bookings(
 
     statement = statement.order_by(Booking.createdAt.desc(), Booking.id.desc())
     return list(session.exec(statement))
+
+_ACTION_MAP: dict[str, tuple] = {
+    "approve": (approve_booking, NotificationType.APPROVED),
+    "deny": (deny_booking, NotificationType.DENIED),
+    "cancel": (cancel_booking, NotificationType.CANCELLED),
+}
+
+
+def process_booking_action(booking_id: int, action: str, session: Session) -> Booking:
+    """Execute a booking lifecycle action and send the corresponding notification."""
+    action_fn, notification_type = _ACTION_MAP[action]
+    booking = action_fn(booking_id, session)
+    send_notification(booking.userID, booking.id, notification_type, session)
+    return booking

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -51,6 +51,14 @@ def get_notifications(user_id, session: Session) -> list[Notification]:
     )
     return list(session.exec(statement))
 
+def get_notification_for_user(notification_id: int, user_id, session: Session) -> Notification:
+    notification = session.get(Notification, notification_id)
+    if notification is None or notification.userID != user_id:
+        raise NotificationNotFoundError(
+            f"Notification {notification_id} was not found."
+        )
+    return notification
+
 
 def mark_read(notification_id: int, session: Session) -> Notification:
     notification = session.get(Notification, notification_id)

--- a/backend/app/services/room_service.py
+++ b/backend/app/services/room_service.py
@@ -6,14 +6,21 @@ This module provides services for retrieving room information and availability.
 from datetime import date
 from typing import List
 
-from fastapi import HTTPException
-from sqlalchemy import and_, extract, func
+from sqlalchemy import and_, extract
 from sqlalchemy.orm import contains_eager
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.booking import TimeSlot, TimeslotStatus
 from app.models.room import Room
+
+
+class RoomServiceError(ValueError):
+    """Base room service error."""
+
+
+class RoomNotFoundError(RoomServiceError):
+    """Raised when a room cannot be found."""
 
 
 async def get_rooms_with_availability(
@@ -59,11 +66,7 @@ async def get_available_dates(
 
 
 async def get_room(room_id: int, session: AsyncSession) -> Room:
-    """
-    Return a single Room by its primary key, or raise an appropriate error
-    (e.g. HTTPException 404) if no room with that ID exists.
-    """
     room = await session.get(Room, room_id)
     if not room:
-        raise HTTPException(status_code=404, detail=f"Room with ID {room_id} not found")
+        raise RoomNotFoundError(f"Room with ID {room_id} not found")
     return room

--- a/backend/app/services/user_manager.py
+++ b/backend/app/services/user_manager.py
@@ -42,13 +42,20 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         """
         Admin-only service function to update a user's role or deactivate their account.
         """
-        # Session is securely scoped inside user_db
-        return await User.admin_update(
-            user_id,
-            self.user_db.session,  # type: ignore
-            role=role,  # type: ignore
-            is_active=is_active,
-        )
+        session = self.user_db.session  # type: ignore
+        user = await session.get(User, user_id)
+        if not user:
+            return None
+
+        if role is not None:
+            user.role = role
+        if is_active is not None:
+            user.is_active = is_active
+
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
 
 
 async def get_user_manager(user_db: SQLModelUserDatabaseAsync = Depends(get_user_db)):

--- a/backend/tests/test_service_room.py
+++ b/backend/tests/test_service_room.py
@@ -1,7 +1,6 @@
 from datetime import date, time
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
@@ -10,6 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.models.booking import TimeSlot, TimeslotStatus
 from app.models.room import Room
 from app.services.room_service import (
+    RoomNotFoundError,
     get_available_dates,
     get_room,
     get_rooms_with_availability,
@@ -130,10 +130,8 @@ async def test_get_room_returns_room_by_id(session: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_get_room_raises_not_found(session: AsyncSession):
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(RoomNotFoundError, match="not found"):
         await get_room(999, session)
-
-    assert exc.value.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/frontend/src/routes/notifications/+page.svelte
+++ b/frontend/src/routes/notifications/+page.svelte
@@ -1,8 +1,228 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { Card, CardContent } from "$lib/components/ui/card";
+    import { Badge } from "$lib/components/ui/badge";
+    import { Separator } from "$lib/components/ui/separator";
+    import { apiFetch } from "$lib/api";
+
+    type NotificationType = "approved" | "denied" | "cancelled";
+
+    interface Notification {
+        id: number;
+        userID: string;
+        bookingID: number;
+        message: string;
+        type: NotificationType;
+        isRead: boolean;
+        createdAt: string;
+    }
+
+    let notifications: Notification[] = $state([]);
+    let unreadCount: number = $state(0);
+    let loading: boolean = $state(true);
+    let error: string = $state("");
+
+    onMount(async () => {
+        await Promise.all([fetchNotifications(), fetchUnreadCount()]);
+        loading = false;
+    });
+
+    async function fetchNotifications() {
+        try {
+            const data = await apiFetch<Notification[]>("/api/notifications");
+            //newest notification first 
+            notifications = data.sort(
+                (a, b) =>
+                    new Date(b.createdAt).getTime() -
+                    new Date(a.createdAt).getTime(),
+            );
+        } catch (e) {
+            error = "Could not load notifications. Please try again.";
+        }
+    }
+
+    async function fetchUnreadCount() {
+        try {
+            const data = await apiFetch<{ count: number }>(
+                "/api/notifications/unread-count",
+            );
+            unreadCount = data.count ?? 0;
+        } catch {
+            // unread count is non-critical
+        }
+    }
+
+    async function markAsRead(notification: Notification) {
+        if (notification.isRead) return;
+
+        //update
+        notification.isRead = true;
+        notifications = notifications;
+        unreadCount = Math.max(0, unreadCount - 1);
+
+        try {
+            await apiFetch(`/api/notifications/${notification.id}/read`, {
+                method: "PATCH",
+            });
+        } catch {
+            // Revert on failure
+            notification.isRead = false;
+            notifications = notifications;
+            unreadCount += 1;
+        }
+    }
+
+
+    // specifies green/red/neutral for each notification
+    function badgeClass(type: NotificationType): string {
+        if (type === "approved")
+            return "border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-400";
+        if (type === "denied")
+            return "border-red-500/50 bg-red-500/10 text-red-700 dark:text-red-400";
+        return "border-border bg-muted/50 text-muted-foreground";
+    }
+
+    function formatDate(iso: string): string {
+        const date = new Date(iso);
+        const now = new Date();
+        const diffMs = now.getTime() - date.getTime();
+        const diffSec = Math.floor(diffMs / 1000);
+        const diffMin = Math.floor(diffSec / 60);
+        const diffHour = Math.floor(diffMin / 60);
+        const diffDay = Math.floor(diffHour / 24);
+
+        if (diffSec < 60) return "Just now";
+        if (diffMin < 60) return `${diffMin}m ago`;
+        if (diffHour < 24) return `${diffHour}h ago`;
+        if (diffDay < 7) return `${diffDay}d ago`;
+
+        return date.toLocaleDateString("en-CA", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+        });
+    }
+
+    function typeLabel(type: NotificationType): string {
+        return type.charAt(0).toUpperCase() + type.slice(1);
+    }
+</script>
+
 <div class="flex flex-1 flex-col gap-6 p-6">
+    <!-- Header -->
     <div>
-        <h1 class="text-2xl font-semibold tracking-tight">Notifications</h1>
+        <div class="flex items-center gap-2">
+            <h1 class="text-2xl font-semibold tracking-tight">Notifications</h1>
+            {#if unreadCount > 0}
+                <span
+                    class="inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-xs font-bold bg-primary text-primary-foreground"
+                    aria-label="{unreadCount} unread notifications"
+                >
+                    {unreadCount}
+                </span>
+            {/if}
+        </div>
         <p class="text-muted-foreground text-sm">
-            Stay up to date with your latest notifications.
+            Your booking updates and alerts.
         </p>
     </div>
+
+    <Separator />
+
+    {#if loading}
+        <div class="flex flex-col gap-3">
+            {#each Array(4) as _}
+                <div
+                    class="rounded-xl border bg-card p-4 flex flex-col gap-2 animate-pulse"
+                >
+                    <div class="h-3 rounded-full bg-muted w-4/5"></div>
+                    <div class="h-3 rounded-full bg-muted w-2/5"></div>
+                    <div class="h-3 rounded-full bg-muted w-1/3"></div>
+                </div>
+            {/each}
+        </div>
+
+    {:else if error}
+        <div
+            class="text-muted-foreground flex flex-1 items-center justify-center text-sm"
+        >
+            {error}
+        </div>
+
+    {:else if notifications.length === 0}
+        <div
+            class="text-muted-foreground flex flex-1 items-center justify-center text-sm"
+        >
+            No notifications yet. When your bookings are approved, denied, or
+            cancelled, you'll see updates here.
+        </div>
+
+    {:else}
+        <ul class="flex flex-col gap-3" aria-label="Notifications">
+            {#each notifications as notification (notification.id)}
+                <li>
+                    <button
+                        class="w-full text-left disabled:cursor-default"
+                        disabled={notification.isRead}
+                        onclick={() => markAsRead(notification)}
+                    >
+                        <Card
+                            class="transition-all duration-150 {notification.isRead
+                                ? 'opacity-60'
+                                : 'border-primary/30 bg-primary/[0.02] hover:shadow-md hover:-translate-y-px cursor-pointer'}"
+                        >
+                            <CardContent class="flex items-start gap-3 p-4">
+                                <!-- Unread/read dot indicator -->
+                                <div class="pt-1 shrink-0" aria-hidden="true">
+                                    {#if !notification.isRead}
+                                        <span
+                                            class="block w-2 h-2 rounded-full bg-primary ring-2 ring-primary/20"
+                                        ></span>
+                                    {:else}
+                                        <span
+                                            class="block w-2 h-2 rounded-full bg-muted"
+                                        ></span>
+                                    {/if}
+                                </div>
+
+                                <div class="flex-1 min-w-0 flex flex-col gap-1">
+                                    <div
+                                        class="flex items-start justify-between gap-3"
+                                    >
+                                        <!-- Message (bold when unread) -->
+                                        <p
+                                            class="text-sm leading-snug {notification.isRead
+                                                ? 'font-normal'
+                                                : 'font-semibold'}"
+                                        >
+                                            {notification.message}
+                                        </p>
+
+                                        <!-- Type badge: green=approved, red=denied, neutral=cancelled -->
+                                        <Badge
+                                            variant="outline"
+                                            class="shrink-0 text-xs uppercase tracking-wide {badgeClass(notification.type)}"
+                                        >
+                                            {typeLabel(notification.type)}
+                                        </Badge>
+                                    </div>
+
+                                    <!-- Timestamp -->
+                                    <time
+                                        class="text-xs text-muted-foreground"
+                                        datetime={notification.createdAt}
+                                        title={new Date(
+                                            notification.createdAt,
+                                        ).toLocaleString()}
+                                    >
+                                        {formatDate(notification.createdAt)}
+                                    </time>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </button>
+                </li>
+            {/each}
+        </ul>
+    {/if}
 </div>


### PR DESCRIPTION
This PR addresses four boundary violations identified during the routes/services/models separation of concerns audit.

1. room_service.py — Removed HTTPException from the service layer.
The service was importing and raising HTTPException directly. Defined RoomServiceError/RoomNotFoundError following the existing booking/notification error pattern. The route now catches the domain exception and translates to 404.

2. models/user.py — Moved session management out of the model.
User.admin_update() was a class method that ran a full query/commit/refresh cycle. Moved that logic into UserManager.admin_update_user() where the session is already managed in the correct layer. Models can mutate their own fields but session lifecycle belongs in the service layer in accordance with our lectures.

3. routes/notifications.py — Removed the direct DB query from route.
A route-level helper was calling session.get() and checking notification ownership inline. Added get_notification_for_user() to the notification service and delegated from the route, matching how all other service calls in the file work.

4. routes/bookings.py — Moved multi-step orchestration into the service layer.
The booking PATCH route was sequencing two service calls (action + notification) inline. Added process_booking_action() to the booking service to wrap both steps. The route now makes a single delegation call to the service layer.